### PR TITLE
GCP Mailer Provider functionality

### DIFF
--- a/tools/c7n_mailer/README.md
+++ b/tools/c7n_mailer/README.md
@@ -1,8 +1,4 @@
-# c7n-mailer: Custodian Mailer
-
-[//]: # (         !!! IMPORTANT !!!                    )
-[//]: # (This file is moved during document generation.)
-[//]: # (Only edit the original document at ./tools/c7n_mailer/README.md)
+# Custodian Mailer
 
 A mailer implementation for Custodian. Outbound mail delivery is still somewhat
 organization-specific, so this at the moment serves primarily as an example
@@ -25,17 +21,17 @@ and run a policy that triggers an email to your inbox.
 
 1. [Install](#developer-install-os-x-el-capitan) the mailer on your laptop (if you are not running as a [Docker container](https://hub.docker.com/r/cloudcustodian/mailer)
    - or use `pip install c7n-mailer`
-2. In your text editor, create a `mailer.yml` file to hold your mailer config.
-3. In the AWS console, create a new standard SQS queue (quick create is fine).
+1. In your text editor, create a `mailer.yml` file to hold your mailer config.
+1. In the AWS console, create a new standard SQS queue (quick create is fine).
    Copy the queue URL to `queue_url` in `mailer.yml`.
-4. In AWS, locate or create a role that has read access to the queue. Grab the
+1. In AWS, locate or create a role that has read access to the queue. Grab the
    role ARN and set it as `role` in `mailer.yml`.
 
 there is different notification endpoints options, you can combine both.
 
 ### Email:
 Make sure your email address is verified in SES, and set it as
-`from_address` in `mailer.yml`. By default SES is in sandbox mode where you
+   `from_address` in `mailer.yml`. By default SES is in sandbox mode where you
 must
 [verify](http://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html)
 every individual recipient of emails. If need be, make an AWS support ticket to
@@ -53,14 +49,14 @@ from_address: you@example.com
 
 Now let's make a Custodian policy to populate your mailer queue. Create a
 `test-policy.yml` file with this content (update `to` and `queue` to match your
-environment)
+environment):
 
 ```yaml
-  policies:
+policies:
   - name: c7n-mailer-test
     resource: sqs
     filters:
-      - "tag:MailerTest": absent
+     - "tag:MailerTest": absent
     actions:
       - type: notify
         template: default
@@ -178,8 +174,6 @@ Delivery via tag has been tested with webhooks but should support all delivery m
 c7n-mailer --config mailer.yml --update-lambda && custodian run -c test-policy.yml -s .
 ```
 
-Note: You can set the profile via environment variable e.g. `export AWS_DEFAULT_PROFILE=foo`
-
 You should see output similar to the following:
 
 ```
@@ -212,10 +206,10 @@ c7n-mailer: error: argument -c/--config is required
 ```
 
 Fundamentally what `c7n-mailer` does is deploy a Lambda (using
-[Mu](http://cloudcustodian.io/docs/policy/mu.html)) based on
+[Mu](http://www.capitalone.io/cloud-custodian/docs/policy/mu.html)) based on
 configuration you specify in a YAML file.  Here is [the
-schema](./c7n_mailer/cli.py#L11-L41) to which the file must conform,
-and here is a description of the options:
+schema](./c7n_mailer/cli.py#L11-L41) to which the file must conform, here is
+[an example config](./example.yml), and here is a description of the options:
 
 | Required? | Key                  | Type             | Notes                               |
 |:---------:|:---------------------|:-----------------|:------------------------------------|
@@ -256,8 +250,19 @@ and here is a description of the options:
 |           | `skuTier`                      | string           | Default: `Basic` |
 |           | `skuName`                      | string           | Default: `B1`    |
 
+#### Standard Google Cloud Config
+To configure Mailer to support Google Cloud, you must set the properties below in the config. Please note that Mailer will only run from the command line to support Google Cloud. Deployment of c7n_mailer as a Google Cloud Function is not supported at this time.  Additionally, Mailer for GCP only supports SMTP delivery at this time.
 
-
+| Required? | Key                  | Type             | Notes                               |
+|:---------:|:---------------------|:-----------------|:------------------------------------|
+| &#x2705;  | `queue_url`       | string           | set to the url path of the gcp subscription |                                    |
+|           | `from_address`       | string           | default from address that messages are sent from                |
+|           | `contact_tags`       | array of strings | tags(labels) that we should look at for address information |
+|           | `smtp_server`        | string           | Your smtp server ip address or hostname |
+|           | `smtp_port`          | integer          | smtp port                           |
+|           | `smtp_ssl`           | boolean          | this defaults to True               |
+|           | `smtp_username`      | string           |                                     |
+|           | `smtp_password`      | string           |                                     |
 
 #### Mailer Infrastructure Config
 
@@ -404,7 +409,7 @@ mailer is running under.
 The notify action in your policy will reflect transport type `asq` with the URL
 to an Azure Storage Queue.  For example:
 
-```yaml
+```json
 policies:
   - name: azure-notify
     resource: azure.resourcegroup
@@ -424,7 +429,7 @@ policies:
 In your mailer configuration, you'll need to provide your SendGrid API key as well as
 prefix your queue URL with `asq://` to let mailer know what type of queue it is:
 
-```yaml
+```yml
 queue_url: asq://storageaccount.queue.core.windows.net/queuename
 from_address: you@youremail.com
 sendgrid_api_key: SENDGRID_API_KEY
@@ -443,7 +448,7 @@ mailer configuration.
 
 where `mailer.yml` may look like:
 
-```yaml
+```yml
 queue_url: asq://storage.queue.core.windows.net/custodian
 from_address: foo@mail.com
 sendgrid_api_key: <key>
@@ -455,11 +460,59 @@ function_properties:
     skuName: B1
     location: WestUS2
 ```
+## Using on GCP
+
+Requires:
+
+- `c7n_gcp` package.  See [GCP Getting Started](https://cloudcustodian.io/docs/gcp/gettingstarted.html)
+- A working SMTP Account. 
+- [GCP Pubsub Subscription](https://cloud.google.com/pubsub/docs/)
+
+The mailer supports GCP Pubsub transports and SMTP/Email delivery.
+Configuration for this scenario requires only minor changes from AWS deployments.
+
+The notify action in your policy will reflect transport type `asq` with the URL
+to an Azure Storage Queue.  For example:
+
+```yml
+policies:
+  - name: gcp-notify
+    resource: gcp.compute
+    description: example policy
+    actions:
+      - type: notify
+        template: default
+        priority_header: '2'
+        subject: Hello from C7N Mailer
+        to:
+          - you@youremail.com
+        transport:
+          type: pubsub
+          topic: projects/myproject/topics/mytopic
+```
+
+In your mailer configuration, you'll need to provide your SMTP account information 
+as well as your topic subscription path in the queue_url variable. Please note that the 
+subscription you specify should be subscribed to the topic you assign in your policies' 
+notify action for GCP resources. 
+
+```yml
+queue_url: projects/myproject/subscriptions/mysubscription
+from_address: you@youremail.com
+smtp_server: my.smtp.add.ress
+smtp_port: 25
+smtp_ssl: True
+smtp_username: smtpuser
+smtp_password: smtppassword
+```
+
+The mailer will transmit all messages found on the queue on each execution using SMTP/Email delivery. 
 
 ## Writing an email template
 
 Templates are authored in [jinja2](http://jinja.pocoo.org/docs/dev/templates/).
-Drop a file with the `.j2` extension into the a templates directory, and send a pull request to this
+Drop a file with the `.j2` extension into the
+[`c7n_mailer/msg-templates`](./c7n_mailer/msg-templates) directory, and send a pull request to this
 repo. You can then reference it in the `notify` action as the `template`
 variable by file name minus extension. Templates ending with `.html.j2` are
 sent as HTML-formatted emails, all others are sent as plain text.
@@ -476,8 +529,6 @@ The following variables are available when rendering templates:
 | `action` | `notify` action that generated this SQS message |
 | `policy` | policy that triggered this notify action |
 | `account` | short name of the aws account |
-| `region`  | region the policy was executing in |
-| `execution_start` | The time policy started executing |
 
 The following extra global functions are available:
 
@@ -486,9 +537,6 @@ The following extra global functions are available:
 | `format_struct(struct)` | pretty print a json structure |
 | `resource_tag(resource, key)` | retrieve a tag value from a resource or return an empty string, aliased as get_resource_tag_value |
 | `format_resource(resource, resource_type)` | renders a one line summary of a resource |
-| `date_time_format(utc_str, tz_str='US/Eastern', format='%Y %b %d %H:%M %Z')`| customize rendering of an utc datetime string |
-| `seach(expression, value)` | jmespath search value using expression |
-| `yaml_safe(value)` | yaml dumper |
 
 The following extra jinja filters are available:
 
@@ -502,7 +550,7 @@ The following extra jinja filters are available:
 
 Clone the repository:
 ```
-$ git clone https://github.com/cloud-custodian/cloud-custodian
+$ git clone https://github.com/capitalone/cloud-custodian
 ```
 Install dependencies (with virtualenv):
 ```

--- a/tools/c7n_mailer/c7n_mailer/cli.py
+++ b/tools/c7n_mailer/c7n_mailer/cli.py
@@ -12,7 +12,8 @@ from c7n_mailer.azure.azure_queue_processor import MailerAzureQueueProcessor
 from c7n_mailer.azure import deploy as azure_deploy
 from c7n_mailer.gcp.gcp_pubsub_processor import MailerGcpPubSubProcessor
 from c7n_mailer.sqs_queue_processor import MailerSqsQueueProcessor
-from ruamel import yaml
+from ruamel import yml
+
 
 CONFIG_SCHEMA = {
     'type': 'object',
@@ -214,6 +215,7 @@ def main():
             azure_deploy.provision(mailer_config)
         elif is_gcp_cloud(mailer_config):
             print('Deploying mailer as a google cloud function is not supported at this time.')
+
         else:
             deploy.provision(mailer_config, functools.partial(session_factory, mailer_config))
 

--- a/tools/c7n_mailer/c7n_mailer/cli.py
+++ b/tools/c7n_mailer/c7n_mailer/cli.py
@@ -10,6 +10,7 @@ import jsonschema
 from c7n_mailer import deploy, utils
 from c7n_mailer.azure.azure_queue_processor import MailerAzureQueueProcessor
 from c7n_mailer.azure import deploy as azure_deploy
+from c7n_mailer.gcp.gcp_pubsub_processor import MailerGcpPubSubProcessor
 from c7n_mailer.sqs_queue_processor import MailerSqsQueueProcessor
 from ruamel import yaml
 
@@ -179,6 +180,10 @@ def is_azure_cloud(mailer_config):
     return mailer_config.get('queue_url').startswith('asq')
 
 
+def is_gcp_cloud(mailer_config):
+    return mailer_config.get('queue_url').startswith('projects')
+
+
 def main():
     parser = get_c7n_mailer_parser()
     args = parser.parse_args()
@@ -207,6 +212,8 @@ def main():
 
         if is_azure_cloud(mailer_config):
             azure_deploy.provision(mailer_config)
+        elif is_gcp_cloud(mailer_config):
+            print('Deploying mailer as a google cloud function is not supported at this time.')
         else:
             deploy.provision(mailer_config, functools.partial(session_factory, mailer_config))
 
@@ -216,6 +223,8 @@ def main():
         # Select correct processor
         if is_azure_cloud(mailer_config):
             processor = MailerAzureQueueProcessor(mailer_config, logger)
+        elif is_gcp_cloud(mailer_config):
+            processor = MailerGcpPubSubProcessor(mailer_config, logger)
         else:
             aws_session = session_factory(mailer_config)
             processor = MailerSqsQueueProcessor(mailer_config, aws_session, logger)

--- a/tools/c7n_mailer/c7n_mailer/cli.py
+++ b/tools/c7n_mailer/c7n_mailer/cli.py
@@ -12,7 +12,7 @@ from c7n_mailer.azure.azure_queue_processor import MailerAzureQueueProcessor
 from c7n_mailer.azure import deploy as azure_deploy
 from c7n_mailer.gcp.gcp_pubsub_processor import MailerGcpPubSubProcessor
 from c7n_mailer.sqs_queue_processor import MailerSqsQueueProcessor
-from ruamel import yml
+from ruamel import yaml
 
 
 CONFIG_SCHEMA = {

--- a/tools/c7n_mailer/c7n_mailer/email_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/email_delivery.py
@@ -74,7 +74,8 @@ class EmailDelivery(object):
         self.config = config
         self.logger = logger
         self.session = session
-        if not self.config.get('queue_url').startswith('projects'):
+        from .cli import is_gcp_cloud
+        if not is_gcp_cloud(self.config):
             self.aws_ses = session.client('ses', region_name=config.get('ses_region'))
         self.ldap_lookup = self.get_ldap_connection()
 

--- a/tools/c7n_mailer/c7n_mailer/email_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/email_delivery.py
@@ -74,7 +74,8 @@ class EmailDelivery(object):
         self.config = config
         self.logger = logger
         self.session = session
-        self.aws_ses = session.client('ses', region_name=config.get('ses_region'))
+        if not self.config.get('queue_url').startswith('projects'):
+            self.aws_ses = session.client('ses', region_name=config.get('ses_region'))
         self.ldap_lookup = self.get_ldap_connection()
 
     def get_ldap_connection(self):
@@ -275,7 +276,6 @@ class EmailDelivery(object):
             priority = PRIORITIES[str(priority)].copy()
             for key in priority:
                 message[key] = priority[key]
-
         return message
 
     def get_mimetext_message(self, sqs_message, resources, to_addrs):

--- a/tools/c7n_mailer/c7n_mailer/gcp/gcp_pubsub_processor.py
+++ b/tools/c7n_mailer/c7n_mailer/gcp/gcp_pubsub_processor.py
@@ -1,0 +1,95 @@
+# Copyright 2019 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+GCP Pub-Sub Message Processing
+==============================
+"""
+
+import six
+from c7n_mailer.email_delivery import EmailDelivery
+import base64
+import zlib
+
+
+class MailerGcpPubSubProcessor(object):
+
+    def __init__(self, config, logger, session=None):
+        self.config = config
+        self.logger = logger
+        self.subscription = self.config['queue_url']
+        self.session = session
+
+    def run(self):
+        self.logger.info("Downloading messages from the GCP PubSub Subscription.")
+
+        # Get first set of messages to process
+        messages = self.receive_messages()
+
+        while len(messages) > 0:
+            # Discard_date is the timestamp of the last published message in the messages list
+            # and will be the date we need to seek to when we ack_messages
+            discard_date = messages['receivedMessages'][-1]['message']['publishTime']
+
+            # Process received messages
+            for message in messages['receivedMessages']:
+                self.process_message(message)
+
+            # Acknowledge and purge processed messages then get next set of messages
+            self.ack_messages(discard_date)
+            messages = self.receive_messages()
+
+        self.logger.info('No messages left in the gcp topic subscription, now exiting c7n_mailer.')
+
+    # This function, when processing gcp pubsub messages, will only deliver messages over email.
+    # TODO: Slack and Datadog integration or wait for future redesign
+    def process_message(self, encoded_gcp_pubsub_message):
+        pubsub_message = self.unpack(encoded_gcp_pubsub_message['message']['data'])
+        delivery = EmailDelivery(self.config, self.session, self.logger)
+        to_email_messages_map = delivery.get_to_addrs_email_messages_map(
+            pubsub_message)
+        for email_to_addrs, mimetext_msg in six.iteritems(to_email_messages_map):
+            delivery.send_c7n_email(pubsub_message, list(email_to_addrs), mimetext_msg)
+
+    def receive_messages(self):
+        """Receive messsage(s) from subscribed topic
+        """
+        client = self.session.client('pubsub', 'v1', 'projects.subscriptions')
+
+        return client.execute_command('pull', {
+            'subscription': self.subscription,
+            'body': {
+                'returnImmediately': True
+            }
+        })
+
+    def ack_messages(self, discard_datetime):
+        """Acknowledge and Discard messages up to datetime using seek api command
+        """
+        client = self.session.client('pubsub', 'v1', 'projects.subscriptions')
+
+        return client.execute_command('seek', {
+            'subscription': self.subscription,
+            'body': {
+                'time': discard_datetime
+            }
+        })
+
+    @staticmethod
+    def unpack(encoded_gcp_pubsub_message):
+        """ Returns a message that been base64 decoded
+        """
+        b64decoded = base64.b64decode(encoded_gcp_pubsub_message)
+        uncompressed = zlib.decompress(b64decoded)
+        return uncompressed

--- a/tools/c7n_mailer/c7n_mailer/gcp/gcp_pubsub_processor.py
+++ b/tools/c7n_mailer/c7n_mailer/gcp/gcp_pubsub_processor.py
@@ -29,6 +29,7 @@ class MailerGcpPubSubProcessor(object):
         self.logger = logger
         self.subscription = self.config['queue_url']
         self.session = session or Session()
+        self.client = self.session.client('pubsub', 'v1', 'projects.subscriptions')
 
     def run(self):
         self.logger.info("Downloading messages from the GCP PubSub Subscription.")
@@ -64,9 +65,7 @@ class MailerGcpPubSubProcessor(object):
     def receive_messages(self):
         """Receive messsage(s) from subscribed topic
         """
-        client = self.session.client('pubsub', 'v1', 'projects.subscriptions')
-
-        return client.execute_command('pull', {
+        return self.client.execute_command('pull', {
             'subscription': self.subscription,
             'body': {
                 'returnImmediately': True,
@@ -77,9 +76,7 @@ class MailerGcpPubSubProcessor(object):
     def ack_messages(self, discard_datetime):
         """Acknowledge and Discard messages up to datetime using seek api command
         """
-        client = self.session.client('pubsub', 'v1', 'projects.subscriptions')
-
-        return client.execute_command('seek', {
+        return self.client.execute_command('seek', {
             'subscription': self.subscription,
             'body': {
                 'time': discard_datetime

--- a/tools/c7n_mailer/tests/common.py
+++ b/tools/c7n_mailer/tests/common.py
@@ -56,6 +56,18 @@ MAILER_CONFIG = {
                           os.path.abspath('/')],
 }
 
+MAILER_CONFIG_1 = {
+    'smtp_port': 25,
+    'smtp_ssl': False,
+    'smtp_username': 'user',
+    'smtp_password': 'password',
+    'from_address': 'devops@initech.com',
+    'queue_url': 'projects/c7n-dev/subscriptions/getnotify',
+    'smtp_server': 'smtp.inittech.com',
+    'templates_folders': [os.path.abspath(os.path.dirname(__file__)),
+                          os.path.abspath('/')],
+}
+
 MAILER_CONFIG_AZURE = {
     'queue_url': 'asq://storageaccount.queue.core.windows.net/queuename',
     'from_address': 'you@youremail.com',
@@ -232,6 +244,38 @@ SQS_MESSAGE_4 = {
     'event': None,
     'resources': [RESOURCE_1]
 }
+
+GCP_MESSAGES = {'receivedMessages': [{'ackId': 'TgQhIT4wPkVTRFAGFixdRkhRNxkIaFEOT14jPzUgKEURCAgUBXx9cURLdV9bGgdRDRlyfGckOFgUBwtCUXZVWxENem1cVzhUCRB1eWF8algbAwVAVH53_pGKmvCVOR1tNcH7qrdASszD_492Zho9XxJLLD5-Ki1FQV5AEkwhGERJUytDCypYEQ', 'message': {'data': 'eJzVUrtuwzAM3PUVhuY6GQNk6tStX1AUgULTrgqZFCQqgBHk36tHHm6nolsHDbrDHe9EnZXGE5LofUfJuSelDQAnkoMdMqZhR/2AJ/0gfqABJ8tUQONcATw7C0sGzkqTmbFQglF6YrHj0jSRU4BKTeA3Ph1jOvbC3kLhR+sEQ8z0m1q5+MCfCBK31/HbKqjXw9VcXdR7jSo51N1AFl8NHgkEZ++MVHTA0SQnBc4pyoRbZEtT1zRdc6xSrrY6RQzPA8/G0gZ41nWwBEPRc5DW/za4FWzq0vHXZXIddbkX+m76D9usdv+X7WZ5vu1fjcAHDi+rX9JcymOV8wVn/efe', 'messageId': '549740902827570', 'publishTime': '2019-05-13T18:31:17.926Z'}}, {'ackId': 'EU4EISE-MD5FU0RQBhYsXUZIUTcZCGhRDk9eIz81IChFEQgIFAV8fXJETnVYM3UHUQ0Zc3swJ2gPGgZREVF0XlEbH1lcfkoCVQQRdHtifGlYEAIBTVJW-tGc_8SVEG87adWQpatUVfyK7YwxZhs9XxJLLD5-Ki1FQV5AEkwhGERJUytDCypY', 'message': {'data': 'eJzVUrtuwzAM3PUVhuY6GQNk6tStX1AUgULTrgqZFCQqgBHk36tHHm6nolsHDbrDHe9EnZXGE5LofUfJuSelDQAnkoMdMqZhR/2AJ/0gfqABJ8tUQONcATw7C0sGzkqTmbFQglF6YrHj0jSRU4BKTeA3Ph1jOvbC3kLhR+sEQ8z0m1q5+MCfCBK31/HbKqjXw9VcXdR7jSo51N1AFl8NHgkEZ++MVHTA0SQnBc4pyoRbZEtT1zRdc6xSrrY6RQzPA8/G0gZ41nWwBEPRc5DW/za4FWzq0vHXZXIddbkX+m76D9usdv+X7WZ5vu1fjcAHDi+rX9JcymOV8wVn/efe', 'messageId': '549866393233381', 'publishTime': '2019-05-13T20:55:05.231Z'}}, {'ackId': 'EU4EISE-MD5FU0RQBhYsXUZIUTcZCGhRDk9eIz81IChFEQgIFAV8fXJETnVYM3UHUQ0Zc3swJ2gPGgZREVF0X1EbH1lcfkoCVQQRd3lgfWxTEwEKQVRW-tGc_8SVEG87adWQpatUVfyK7YwxZhs9XxJLLD5-Ki1FQV5AEkwhGERJUytDCypY', 'message': {'data': 'eJzVUrtuwzAM3PUVhuY6GQNk6tStX1AUgULTrgqZFCQqgBHk36tHHm6nolsHDbrDHe9EnZXGE5LofUfJuSelDQAnkoMdMqZhR/2AJ/0gfqABJ8tUQONcATw7C0sGzkqTmbFQglF6YrHj0jSRU4BKTeA3Ph1jOvbC3kLhR+sEQ8z0m1q5+MCfCBK31/HbKqjXw9VcXdR7jSo51N1AFl8NHgkEZ++MVHTA0SQnBc4pyoRbZEtT1zRdc6xSrrY6RQzPA8/G0gZ41nWwBEPRc5DW/za4FWzq0vHXZXIddbkX+m76D9usdv+X7WZ5vu1fjcAHDi+rX9JcymOV8wVn/efe', 'messageId': '549854186900847', 'publishTime': '2019-05-13T20:36:47.576Z'}}]}
+
+GCP_MESSAGE = '''{
+    "account": "c7n-dev", 
+    "account_id": "c7n-dev",
+    "action": {
+        "subject": "testing notify action",
+        "template": "default",
+        "to": ["user@domain.com"],
+        "transport": {
+            "topic": "projects/c7n-dev/topics/c7n_notify",
+            "type": "pubsub"},
+        "type": "notify"},
+    "event": null,
+    "policy": {
+        "actions": [{
+            "subject": "testing notify action", 
+            "template": "default", 
+            "to": ["user@domain.com"],
+            "transport": {
+                "topic": "projects/c7n-dev/topics/c7n_notify", 
+                "type": "pubsub"}, 
+            "type": "notify"}], 
+        "filters": [{
+            "name": "projects/c7n-dev/topics/c7n_notify"}],
+        "name": "test-notify",
+        "resource": "gcp.pubsub-topic"}, 
+    "region": "all",
+    "resources": [{
+        "c7n:MatchedFilters": ["name"],
+        "name": "projects/c7n-dev/topics/c7n_notify"}]}'''
 
 ASQ_MESSAGE = '''{
    "account":"subscription",

--- a/tools/c7n_mailer/tests/common.py
+++ b/tools/c7n_mailer/tests/common.py
@@ -245,12 +245,27 @@ SQS_MESSAGE_4 = {
     'resources': [RESOURCE_1]
 }
 
-GCP_MESSAGES = {'receivedMessages': [{'ackId': 'TgQhIT4wPkVTRFAGFixdRkhRNxkIaFEOT14jPzUgKEURCAgUBXx9cURLdV9bGgdRDRlyfGckOFgUBwtCUXZVWxENem1cVzhUCRB1eWF8algbAwVAVH53_pGKmvCVOR1tNcH7qrdASszD_492Zho9XxJLLD5-Ki1FQV5AEkwhGERJUytDCypYEQ', 'message': {'data': 'eJzVUrtuwzAM3PUVhuY6GQNk6tStX1AUgULTrgqZFCQqgBHk36tHHm6nolsHDbrDHe9EnZXGE5LofUfJuSelDQAnkoMdMqZhR/2AJ/0gfqABJ8tUQONcATw7C0sGzkqTmbFQglF6YrHj0jSRU4BKTeA3Ph1jOvbC3kLhR+sEQ8z0m1q5+MCfCBK31/HbKqjXw9VcXdR7jSo51N1AFl8NHgkEZ++MVHTA0SQnBc4pyoRbZEtT1zRdc6xSrrY6RQzPA8/G0gZ41nWwBEPRc5DW/za4FWzq0vHXZXIddbkX+m76D9usdv+X7WZ5vu1fjcAHDi+rX9JcymOV8wVn/efe', 'messageId': '549740902827570', 'publishTime': '2019-05-13T18:31:17.926Z'}}, {'ackId': 'EU4EISE-MD5FU0RQBhYsXUZIUTcZCGhRDk9eIz81IChFEQgIFAV8fXJETnVYM3UHUQ0Zc3swJ2gPGgZREVF0XlEbH1lcfkoCVQQRdHtifGlYEAIBTVJW-tGc_8SVEG87adWQpatUVfyK7YwxZhs9XxJLLD5-Ki1FQV5AEkwhGERJUytDCypY', 'message': {'data': 'eJzVUrtuwzAM3PUVhuY6GQNk6tStX1AUgULTrgqZFCQqgBHk36tHHm6nolsHDbrDHe9EnZXGE5LofUfJuSelDQAnkoMdMqZhR/2AJ/0gfqABJ8tUQONcATw7C0sGzkqTmbFQglF6YrHj0jSRU4BKTeA3Ph1jOvbC3kLhR+sEQ8z0m1q5+MCfCBK31/HbKqjXw9VcXdR7jSo51N1AFl8NHgkEZ++MVHTA0SQnBc4pyoRbZEtT1zRdc6xSrrY6RQzPA8/G0gZ41nWwBEPRc5DW/za4FWzq0vHXZXIddbkX+m76D9usdv+X7WZ5vu1fjcAHDi+rX9JcymOV8wVn/efe', 'messageId': '549866393233381', 'publishTime': '2019-05-13T20:55:05.231Z'}}, {'ackId': 'EU4EISE-MD5FU0RQBhYsXUZIUTcZCGhRDk9eIz81IChFEQgIFAV8fXJETnVYM3UHUQ0Zc3swJ2gPGgZREVF0X1EbH1lcfkoCVQQRd3lgfWxTEwEKQVRW-tGc_8SVEG87adWQpatUVfyK7YwxZhs9XxJLLD5-Ki1FQV5AEkwhGERJUytDCypY', 'message': {'data': 'eJzVUrtuwzAM3PUVhuY6GQNk6tStX1AUgULTrgqZFCQqgBHk36tHHm6nolsHDbrDHe9EnZXGE5LofUfJuSelDQAnkoMdMqZhR/2AJ/0gfqABJ8tUQONcATw7C0sGzkqTmbFQglF6YrHj0jSRU4BKTeA3Ph1jOvbC3kLhR+sEQ8z0m1q5+MCfCBK31/HbKqjXw9VcXdR7jSo51N1AFl8NHgkEZ++MVHTA0SQnBc4pyoRbZEtT1zRdc6xSrrY6RQzPA8/G0gZ41nWwBEPRc5DW/za4FWzq0vHXZXIddbkX+m76D9usdv+X7WZ5vu1fjcAHDi+rX9JcymOV8wVn/efe', 'messageId': '549854186900847', 'publishTime': '2019-05-13T20:36:47.576Z'}}]}
+GCP_MESSAGES = {
+    'receivedMessages': [{
+        'ackId': 'TgQhIT4wPkVTRFAGFixdRkhRNxkIaFEOT14jPzUgKEURCAgUBXx9cURLdV9bGgdRDRlyfGckOFgUBwtC'
+                 'UXZVWxENem1cVzhUCRB1eWF8algbAwVAVH53_pGKmvCVOR1tNcH7qrdASszD_492Zho9XxJLLD5-Ki1F'
+                 'QV5AEkwhGERJUytDCypYEQ',
+        'message': {
+            'data': 'eJzVUrtuwzAM3PUVhuY6GQNk6tStX1AUgULTrgqZFCQqgBHk36tHHm6nolsHDbrDHe9EnZXGE5Lof'
+                    'UfJuSelDQAnkoMdMqZhR/2AJ/0gfqABJ8tUQONcATw7C0sGzkqTmbFQglF6YrHj0jSRU4BKTeA3Ph'
+                    '1jOvbC3kLhR+sEQ8z0m1q5+MCfCBK31/HbKqjXw9VcXdR7jSo51N1AFl8NHgkEZ++MVHTA0SQnBc4'
+                    'pyoRbZEtT1zRdc6xSrrY6RQzPA8/G0gZ41nWwBEPRc5DW/za4FWzq0vHXZXIddbkX+m76D9usdv+X'
+                    '7WZ5vu1fjcAHDi+rX9JcymOV8wVn/efe',
+            'messageId': '549740902827570',
+            'publishTime': '2019-05-13T18:31:17.926Z'
+        }
+    }]
+}
 
 GCP_MESSAGE = '''{
-    "account": "c7n-dev", 
+    "account": "c7n-dev",
     "account_id": "c7n-dev",
-    "action": {
+        "action": {
         "subject": "testing notify action",
         "template": "default",
         "to": ["user@domain.com"],
@@ -261,17 +276,17 @@ GCP_MESSAGE = '''{
     "event": null,
     "policy": {
         "actions": [{
-            "subject": "testing notify action", 
-            "template": "default", 
+            "subject": "testing notify action",
+            "template": "default",
             "to": ["user@domain.com"],
             "transport": {
-                "topic": "projects/c7n-dev/topics/c7n_notify", 
-                "type": "pubsub"}, 
-            "type": "notify"}], 
+                "topic": "projects/c7n-dev/topics/c7n_notify",
+                "type": "pubsub"},
+            "type": "notify"}],
         "filters": [{
             "name": "projects/c7n-dev/topics/c7n_notify"}],
         "name": "test-notify",
-        "resource": "gcp.pubsub-topic"}, 
+        "resource": "gcp.pubsub-topic"},
     "region": "all",
     "resources": [{
         "c7n:MatchedFilters": ["name"],

--- a/tools/c7n_mailer/tests/test_gcp.py
+++ b/tools/c7n_mailer/tests/test_gcp.py
@@ -1,0 +1,55 @@
+# Copyright 2019 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import json
+import unittest
+import zlib
+from common import logger, MAILER_CONFIG, GCP_MESSAGE
+from c7n_mailer.gcp.gcp_pubsub_processor import MailerGcpPubSubProcessor
+from mock import MagicMock, patch
+
+
+class GcpTest(unittest.TestCase):
+
+    def setUp(self):
+        self.compressed_message = MagicMock()
+        self.compressed_message.content = base64.b64encode(
+            zlib.compress(GCP_MESSAGE.encode('utf8')))
+        self.loaded_message = json.loads(GCP_MESSAGE)
+
+    @patch('c7n_mailer.email_delivery.get_to_addrs_email_messages_map')
+    def test_process_azure_queue_message_success(self, mock_get_addr):
+        p = MailerGcpPubSubProcessor(MAILER_CONFIG, logger)
+        self.assertTrue(p.process_message(self.compressed_message))
+        mock_get_addr.assert_called_with(self.loaded_message)
+
+    @patch('c7n_mailer.email_delivery.get_to_addrs_email_messages_map')
+    def test_process_azure_queue_message_failure(self, mock_get_addr):
+        p = MailerGcpPubSubProcessor(MAILER_CONFIG, logger)
+        self.assertFalse(p.process_message(self.compressed_message))
+        mock_get_addr.assert_called_with(self.loaded_message)
+
+    @patch.object(MailerGcpPubSubProcessor, 'process_message')
+    @patch.object(MailerGcpPubSubProcessor, 'ack_messages')
+    @patch.object(MailerGcpPubSubProcessor, 'receive_messages')
+    def test_run(self, mock_get_message, mock_ack, mock_process):
+        mock_get_message.side_effect = [[self.compressed_message], []]
+        mock_ack.return_value = True
+        mock_process.return_value = True
+        p = MailerGcpPubSubProcessor(MAILER_CONFIG, logger)
+        p.run()
+        self.assertEqual(2, mock_get_message.call_count)
+        self.assertEqual(1, mock_process.call_count)
+        mock_ack.assert_called()


### PR DESCRIPTION
This enhancement to the c7n_mailer tool adds gcp support. The following items were included in this PR:

- GCP Pub Sub message processing.
- Notification delivery via EmailDelivery. (Slack & Datadog integration parity coming soon in subsequent PRs)
- Basic Unit Tests
- Modification/updates to README.md to include GCP Config information.

Functionality has been tested and verified using mailtrap.io smtp testing servers. 

The process flow for GCP Mailer is as follows:

- Custodian GCP Policy sends notification to GCP PubSub Topic as normal.
- C7N_Mailer is run from the command line (Google Cloud functions are not supported at this time)
- The GCP Mailer processor retrieves all messages from the queue and processes each message.
- For each message, it will send notification to the list of "To" email addresses using SMTP infrastructure configured in the config file.

How to test this code:

1. gcloud auth login
2. Create a gcp pubsub topic(for instance: gcp-notify-test1) and add a "PULL" subscription to that topic
3. Create an example policy similar to this or use another gcp resource which as resources:

```yaml
policies:
  name: gcp-notify-test-for-mailer
  resource: gcp.function
  actions:
    type: notify
      template: default
      subject: 'testing the c7n mailer'
      to:
        testuser@example.com
      transport:
        type: pubsub
        topic: gcp-notify-test1
```
4. Run python cli.py -c mailerconfig.yml --run